### PR TITLE
Avoid memory limit oog

### DIFF
--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -77,20 +77,14 @@ library Simulator {
         // Simulate the UserOperation and handle revert
         try IEntryPointSimulationsV060(onEntryPoint).simulateValidation(userOp) { }
         catch (bytes memory reason) {
-            bytes memory _reason;
+            uint256 sigFailed;
+            // selector (4 bytes) + length(32 bytes) + preOpGas(32 bytes)
+            // + prefund (32 bytes) + sigFailed (32 bytes)
+            uint256 pos = 4 + 32 + 32 + 32;
             assembly {
-                _reason := add(4, reason)
+                sigFailed := mload(add(reason, pos))
             }
-            (IEntryPointSimulationsV060.ReturnInfo memory returnInfo,,,) = abi.decode(
-                _reason,
-                (
-                    IEntryPointSimulationsV060.ReturnInfo,
-                    IStakeManager.StakeInfo,
-                    IStakeManager.StakeInfo,
-                    IStakeManager.StakeInfo
-                )
-            );
-            if (returnInfo.sigFailed) {
+            if (sigFailed == 1) {
                 revert("Simulation error: signature failed");
             }
         }

--- a/src/SpecsParser.sol
+++ b/src/SpecsParser.sol
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {
-    IEntryPoint,
-    IEntryPointSimulations,
-    IStakeManager,
-    ENTRYPOINT_ADDR,
-    UserOperationDetails
-} from "./lib/ERC4337.sol";
+import { IStakeManager, ENTRYPOINT_ADDR, UserOperationDetails } from "./lib/ERC4337.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 import { getLabel, getMappingKeyAndParentOf } from "./lib/Vm.sol";
 


### PR DESCRIPTION
# Issue
When testing `erc4337-validation`, `EvmError: MemoryLimitOOG` error will occur in a complex test cases. Later, I found it is beacuse using `abi.decode` to get `sigFailed` will consuming a lot of memory.

# Solution
Use `mload` to get `sigFiled` from `resaon` directly.