### PR TITLE
Fix `depositTo` selector check in OP-052 validation rule

### DIFF
--- a/src/SpecsParser.sol
+++ b/src/SpecsParser.sol
@@ -196,7 +196,7 @@ library ERC4337SpecsParser {
                             (
                                 (callerIsAccount || callerIsFactory)
                                     && currentAccess.data.length > 4
-                                    && bytes4(currentAccess.data) != bytes4(0xb760faf9)
+                                    && bytes4(currentAccess.data) == bytes4(0xb760faf9)
                             ) || (callerIsAccount && currentAccess.data.length == 0)
                         )
                     )


### PR DESCRIPTION
Only `depositTo` call (`bytes4(currentAccess.data) == bytes4(0xb760faf9)`) and fallback (`currentAccess.data.length == 0`) are allowed but it was written as "any call other than `depositTo` is allowed".